### PR TITLE
Fix invite censor bypass by using percent-encoding to hide from the regex

### DIFF
--- a/rowboat/plugins/censor.py
+++ b/rowboat/plugins/censor.py
@@ -2,6 +2,8 @@ import re
 import json
 import urlparse
 
+from urllib import unquote
+
 from holster.enum import Enum
 from disco.types.base import cached_property
 from disco.util.sanitize import S
@@ -190,7 +192,7 @@ class CensorPlugin(Plugin):
             })
 
     def filter_invites(self, event, config):
-        invites = INVITE_LINK_RE.findall(event.content)
+        invites = INVITE_LINK_RE.findall(unquote(event.content))
 
         for _, invite in invites:
             invite_info = self.get_invite_info(invite)

--- a/rowboat/plugins/censor.py
+++ b/rowboat/plugins/censor.py
@@ -209,7 +209,7 @@ class CensorPlugin(Plugin):
 
             if need_whitelist and not whitelisted:
                 raise Censorship(CensorReason.INVITE, event, ctx={
-                    'hit': 'whietlist',
+                    'hit': 'whitelist',
                     'invite': invite,
                     'guild': invite_info,
                 })


### PR DESCRIPTION
```py
>>> print unquote('https://discord.gg/%72%6f%77%62%6f%61%74')
https://discord.gg/rowboat
>>> 
```

you can bypass the invite censor by urlencoding the part of the URL that goes after. Pass it through unquote once and you can get around that.

I also fixed what looks like a typo elsewhere.

