### PR TITLE
Small typo fix

### DIFF
--- a/rowboat/views/dashboard.py
+++ b/rowboat/views/dashboard.py
@@ -45,7 +45,7 @@ def archive(aid, fmt):
             (MessageArchive.expires_at > datetime.utcnow())
         ).get()
     except MessageArchive.DoesNotExist:
-        return 'Invalid or Expires Archive ID', 404
+        return 'Invalid or Expired Archive ID', 404
 
     mime_type = None
     if fmt == 'json':


### PR DESCRIPTION
Just a small typo fix...

It should be "Invalid or Expire**d** Archive ID".
Not "Invalid or Expire**s** Archive ID"

I just felt like to PR this, even though rowboat is gonna be rewritten.
