### PR TITLE
Fix member selection bug

### DIFF
--- a/rowboat/plugins/core.py
+++ b/rowboat/plugins/core.py
@@ -522,7 +522,7 @@ class CorePlugin(Plugin):
                 return event.msg.reply(':warning: only the server owner can setup rowboat')
 
         # Make sure we have admin perms
-        m = event.guild.members.get(id=self.state.me.id)
+        m = event.guild.members.get(self.state.me.id)
         if not m.permissions.administrator and not global_admin:
             return event.msg.reply(':warning: bot must have the Administrator permission')
 

--- a/rowboat/plugins/core.py
+++ b/rowboat/plugins/core.py
@@ -522,7 +522,7 @@ class CorePlugin(Plugin):
                 return event.msg.reply(':warning: only the server owner can setup rowboat')
 
         # Make sure we have admin perms
-        m = event.guild.members.select_one(id=self.state.me.id)
+        m = event.guild.members.get(id=self.state.me.id)
         if not m.permissions.administrator and not global_admin:
             return event.msg.reply(':warning: bot must have the Administrator permission')
 


### PR DESCRIPTION
Using `guild.members.select_one()` returns an error
```
TypeError: select_one() takes exactly 1 argument (2 given)
```
(not 100% sure why)
Using `.get()` instead fixes this, while achieving the same functionality